### PR TITLE
Fix Windows start error

### DIFF
--- a/Galaxo_GUI.py
+++ b/Galaxo_GUI.py
@@ -2,6 +2,7 @@ import threading
 import tkinter as tk
 from tkinter import ttk
 import os
+import sys
 from pyvirtualdisplay import Display
 import atexit
 from GALAXO.PROCESS.GalaxoProcess import GalaxoProcess
@@ -13,7 +14,7 @@ from GALAXO.PROCESS.ProductFactory import ProductFactory
 
 # Start a virtual X display if none is available
 display = None
-if not os.environ.get("DISPLAY"):
+if sys.platform.startswith("linux") and not os.environ.get("DISPLAY"):
     display = Display(visible=False, size=(1024, 768))
     display.start()
     atexit.register(display.stop)


### PR DESCRIPTION
## Summary
- avoid starting `pyvirtualdisplay` on Windows

## Testing
- `python -m py_compile Galaxo_GUI.py`


------
https://chatgpt.com/codex/tasks/task_e_68400e10f840832aa55ea6dd212d8b9d