### PR TITLE
Switch GraphQL to Playwright

### DIFF
--- a/API/PriceHistoryClient.py
+++ b/API/PriceHistoryClient.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from dataclasses import dataclass
 from GALAXO.CONFIG.Constants import Constants
 import base64
+import json
 from playwright.sync_api import sync_playwright
 
 
@@ -36,7 +37,11 @@ class PriceHistoryClient:
                 request_context = p.request.new_context(
                     extra_http_headers=Constants.HEADERS
                 )
-                response = request_context.post(self.BASE_URL, json=payload)
+                response = request_context.post(
+                    self.BASE_URL,
+                    data=json.dumps(payload),
+                    headers={"Content-Type": "application/json"}
+                )
                 return response.json()
         except Exception as e:
             Constants.LOGGER.error(

--- a/PROCESS/ProductClient.py
+++ b/PROCESS/ProductClient.py
@@ -82,5 +82,7 @@ class ProductClient:
             return None
 
     def shutdown(self):
-        """Placeholder for API compatibility."""
-        pass
+        if hasattr(self.details_client, "close"):
+            self.details_client.close()
+        if hasattr(self.availability_client, "close"):
+            self.availability_client.close()


### PR DESCRIPTION
## Summary
- use Playwright for all GraphQL requests
- fix price history requests for current Playwright API
- close Playwright contexts when shutting down clients

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68401039d4e4832a81b519c383215b72