### PR TITLE
Fix GraphQL client without Playwright

### DIFF
--- a/API/GraphQLClient.py
+++ b/API/GraphQLClient.py
@@ -1,38 +1,27 @@
 import json
 import time
-from playwright.sync_api import sync_playwright
+import requests
 from GALAXO.CONFIG.Constants import Constants
 
 class GraphQLClient:
     BASE_URL = Constants.BASE_URL
 
     def __init__(self, max_retries: int = 5, backoff_factor: float = 1.0, timeout: int = 5) -> None:
-        self._playwright = None
-        self._context = None
+        self.session = requests.Session()
         self.max_retries = max_retries
         self.backoff_factor = backoff_factor
         self.timeout = timeout
 
-    def _ensure_context(self):
-        if self._context is None:
-            self._playwright = sync_playwright().start()
-            self._context = self._playwright.request.new_context(
-                extra_http_headers=Constants.HEADERS,
-            )
-        return self._context
-
     def send_request(self, payload):
         for attempt in range(1, self.max_retries + 1):
             try:
-                ctx = self._ensure_context()
-                response = ctx.post(
+                response = self.session.post(
                     self.BASE_URL,
                     data=json.dumps(payload),
-                    headers={"Content-Type": "application/json"},
-                    timeout=self.timeout * 1000,
+                    headers={"Content-Type": "application/json", **Constants.HEADERS},
+                    timeout=self.timeout,
                 )
-                if not response.ok:
-                    raise Exception(f"HTTP {response.status}")
+                response.raise_for_status()
                 response_content = response.json()
 
                 if "errors" in response_content:
@@ -56,9 +45,6 @@ class GraphQLClient:
         self.close()
 
     def close(self) -> None:
-        if self._context:
-            self._context.dispose()
-            self._context = None
-        if self._playwright:
-            self._playwright.stop()
-            self._playwright = None
+        if self.session:
+            self.session.close()
+            self.session = None

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Galaxo ist eine Python-Anwendung mit grafischer Benutzeroberfläche, die Produkt
 2. Abhängigkeiten aus `requirements.txt` installieren:
    ```bash
    pip install -r requirements.txt
-   playwright install
    # optional: for headless environments
    sudo apt-get install -y xvfb
    ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests
 Pillow
-playwright
 pyvirtualdisplay
 


### PR DESCRIPTION
## Summary
- drop Playwright usage
- use `requests` for GraphQL and price history calls
- update install docs and dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840135f0f58832a9b1d2e95fd35b825