### PR TITLE
Fix event loop errors on close

### DIFF
--- a/PROCESS/ProductClient.py
+++ b/PROCESS/ProductClient.py
@@ -86,3 +86,5 @@ class ProductClient:
             self.details_client.close()
         if hasattr(self.availability_client, "close"):
             self.availability_client.close()
+        if hasattr(self.price_history_client, "close"):
+            self.price_history_client.close()


### PR DESCRIPTION
## Summary
- properly close the price history client when shutting down

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68402726548c832aaf374212e1f472e2