### PR TITLE
Fix tkinter thread initialization error

### DIFF
--- a/Galaxo_GUI.py
+++ b/Galaxo_GUI.py
@@ -40,8 +40,9 @@ class ProductListApp:
         self.category_counts = {}
         
         self._create_widgets()
-        self._load_products()
-        self._check_log()
+        # Load products and check logs after the main loop has started
+        self.root.after_idle(self._load_products)
+        self.root.after_idle(self._check_log)
 
     # --- GUI Setup ---
 


### PR DESCRIPTION
## Summary
- call `_load_products` and `_check_log` using `after_idle`
  to ensure image threads start after the main event loop

## Testing
- `python -m py_compile Galaxo_GUI.py GUI/*.py API/*.py CONFIG/*.py LOGGER/*.py PROCESS/*.py UTILS/*.py GALAXO/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68402c79ad88832a83b415bf1d0a3637