### PR TITLE
Fix window maximize on Linux

### DIFF
--- a/Galaxo_GUI.py
+++ b/Galaxo_GUI.py
@@ -26,7 +26,10 @@ class ProductListApp:
         style.theme_use(Constants.THEME)
         self.root.title(Constants.TITLE)
         try:
-            self.root.state('zoomed')
+            if sys.platform.startswith("linux"):
+                self.root.attributes("-zoomed", True)
+            else:
+                self.root.state('zoomed')
         except tk.TclError:
             self.root.state('normal')
         self.root.configure(bg=Constants.BG_COLOR)


### PR DESCRIPTION
## Summary
- ensure GUI starts maximized on Linux using `attributes("-zoomed", True)`

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_68427349ea20832a90984862eb21ec73