### PR TITLE
Optimize utilities

### DIFF
--- a/API/PriceHistoryClient.py
+++ b/API/PriceHistoryClient.py
@@ -60,9 +60,6 @@ class PriceHistoryClient(GraphQLClient):
             if not price_history:
                 return {"min_price": None, "max_price": None}
 
-            # Sortiere die Liste nach dem Datum (optional, aber falls du eine chronologische Reihenfolge benötigst)
-            price_history.sort(key=lambda x: datetime.fromisoformat(x.valid_from), reverse=True)
-
             # Berechne den minimalen und maximalen Preis
             min_price = min(price_history, key=lambda x: x.amount_incl).amount_incl
             max_price = max(price_history, key=lambda x: x.amount_incl).amount_incl

--- a/UTILS/Utils.py
+++ b/UTILS/Utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+from functools import lru_cache
 from tkinter import font as tkfont
 import tkinter as tk
 from CONFIG.Constants import Constants
@@ -10,6 +11,7 @@ from urllib.parse import urlsplit
 class Utils:
 
     @staticmethod
+    @lru_cache(maxsize=1)
     def get_sort_options():
         return {
                 Constants.SORT_PRICE_UP: lambda x: float(x.current_price),
@@ -22,6 +24,7 @@ class Utils:
         return list(Utils.get_sort_options().keys())
 
     @staticmethod
+    @lru_cache(maxsize=None)
     def create_font(size, weight="normal", family="Arial"):
         return tkfont.Font(family=family, size=size, weight=weight or "normal")
 
@@ -83,9 +86,15 @@ class Utils:
 
     @staticmethod
     def get_file_hash_path(image_url):
-        filename = hashlib.md5(urlsplit(image_url).path.encode()).hexdigest() + ".png"
+        return Utils._cached_hash_path(urlsplit(image_url).path)
+
+    @staticmethod
+    @lru_cache(maxsize=128)
+    def _cached_hash_path(path: str) -> str:
+        filename = hashlib.md5(path.encode()).hexdigest() + ".png"
         return os.path.join(Constants.CACHE_DIR_IMAGES, filename)
 
+    @staticmethod
     def delete_image(image_url):
         try:
             cache_path = Utils.get_file_hash_path(image_url)


### PR DESCRIPTION
## Summary
- memoize sort options and fonts
- cache filename hashing for image retrieval and add missing staticmethod
- remove redundant sort from price history lookup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684529131718832a89b54fb29d79dcca