### PR TITLE
Skip price history on updates

### DIFF
--- a/PROCESS/GalaxoProcess.py
+++ b/PROCESS/GalaxoProcess.py
@@ -41,7 +41,7 @@ class GalaxoProcess:
     def process_update_prices(self):
         for pd in self._cached_products:
             try:
-                details = self.product_client.get_full_product_details(pd.product_id)
+                details = self.product_client.get_full_product_details(pd.product_id, include_price_history=False)
                 if details:
                     ProductFactory.update_existing(pd, details)
             except Exception as e:

--- a/PROCESS/ProductClient.py
+++ b/PROCESS/ProductClient.py
@@ -50,19 +50,21 @@ class ProductClient:
         if self.price_history_client is None:
             self.price_history_client = PriceHistoryClient()
 
-    def get_full_product_details(self, product_id: str) -> Optional[ProductDetails]:
+    def get_full_product_details(self, product_id: str, include_price_history: bool = True) -> Optional[ProductDetails]:
+        """Fetch product details and optionally the price history."""
         self._ensure_clients()
         self.logger.info(f"Fetching full product details for: {product_id}")
         try:
             pdp_data = self.details_client.get_product_details_pdp(product_id)
-
-            try:
-                price_history = self.price_history_client.get_pdp_price_history(product_id)
-            except Exception as e:
-                self.logger.warning(
-                    f"Price history unavailable for {product_id}: {e}", exc_info=True
-                )
-                price_history = {}
+            price_history = {}
+            if include_price_history:
+                try:
+                    price_history = self.price_history_client.get_pdp_price_history(product_id)
+                except Exception as e:
+                    self.logger.warning(
+                        f"Price history unavailable for {product_id}: {e}", exc_info=True
+                    )
+                    price_history = {}
 
             try:
                 stock_count = self.availability_client.get_offer_availability(


### PR DESCRIPTION
## Summary
- add `include_price_history` flag to `get_full_product_details`
- avoid fetching price history when updating existing products

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68452b49624c832a89753faa94ecdb65