### PR TITLE
Switch APIs to requests and parallelize updates

### DIFF
--- a/API/OfferAvailabilityClient.py
+++ b/API/OfferAvailabilityClient.py
@@ -1,6 +1,6 @@
-from API.GraphQLClient import GraphQLClient
+from API.RequestGraphQLClient import RequestGraphQLClient
 
-class OfferAvailabilityClient(GraphQLClient):
+class OfferAvailabilityClient(RequestGraphQLClient):
     
     def get_offer_availability(self, product_id, sales_offer_id, offer_type):
         query = [{

--- a/API/ProductDetailsClient_PDP.py
+++ b/API/ProductDetailsClient_PDP.py
@@ -1,5 +1,5 @@
 from CONFIG.Constants import Constants
-from API.GraphQLClient import GraphQLClient
+from API.RequestGraphQLClient import RequestGraphQLClient
 
 class ProductDetails:
     def __init__(self, name, brand, product_id, price, image_url, product_url, category, offer_id, shop_offer_id,offer_type):
@@ -14,7 +14,7 @@ class ProductDetails:
         self.shop_offer_id = shop_offer_id
         self.offer_type = offer_type
         
-class ProductDetailsClient_PDP(GraphQLClient):
+class ProductDetailsClient_PDP(RequestGraphQLClient):
     
     def get_product_details_pdp(self, product_id):
         

--- a/API/RequestGraphQLClient.py
+++ b/API/RequestGraphQLClient.py
@@ -1,0 +1,54 @@
+import json
+import time
+import requests
+from requests.adapters import HTTPAdapter
+from CONFIG.Constants import Constants
+
+class RequestGraphQLClient:
+    """Lightweight GraphQL client using the requests library."""
+
+    BASE_URL = Constants.BASE_URL
+
+    def __init__(self, max_retries: int = 5, backoff_factor: float = 1.0, timeout: int = 5) -> None:
+        self.max_retries = max_retries
+        self.backoff_factor = backoff_factor
+        self.timeout = timeout
+        self._session = requests.Session()
+        adapter = HTTPAdapter(pool_connections=100, pool_maxsize=100)
+        self._session.mount("https://", adapter)
+        self._session.mount("http://", adapter)
+
+    def send_request(self, payload):
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                resp = self._session.post(
+                    self.BASE_URL,
+                    data=json.dumps(payload),
+                    headers={"Content-Type": "application/json", **Constants.HEADERS},
+                    timeout=self.timeout,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                if "errors" in data:
+                    raise Exception(f"GraphQL errors: {data['errors']}")
+                return data
+            except Exception as e:
+                Constants.LOGGER.warning(
+                    f"[RequestGraphQLClient] Payload: {payload} :Attempt {attempt} failed: {e}"
+                )
+                if attempt == self.max_retries:
+                    Constants.LOGGER.error(
+                        f"[RequestGraphQLClient] Max retries {self.max_retries} reached. Giving up."
+                    )
+                    raise
+                sleep_time = self.backoff_factor * (2 ** (attempt - 1))
+                Constants.LOGGER.info(
+                    f"[RequestGraphQLClient] Retrying in {sleep_time:.1f} seconds..."
+                )
+                time.sleep(sleep_time)
+
+    def close(self) -> None:
+        self._session.close()
+
+    def __del__(self) -> None:
+        self.close()


### PR DESCRIPTION
## Summary
- add lightweight `RequestGraphQLClient` using the `requests` library
- migrate offer and product detail APIs to the new client
- update price update process to perform parallel requests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68452d084b80832abcd24d041d0cc170